### PR TITLE
chore: unify Renovate config with standard template

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,0 @@
-{
-   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-   "extends": [
-     "config:recommended"
-   ]
- }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":prHourlyLimitNone",
+    ":prConcurrentLimitNone"
+  ],
+  "labels": ["dependencies"],
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Automerge minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge all GitHub Actions updates including major",
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Move renovate config from `.github/` to root
- Add semantic commits, dependency labels, PR rate limit presets
- Add platformAutomerge, gomodTidy, and blanket automerge rules for minor/patch/pin/digest
- Automerge all GitHub Actions updates including major versions