### PR TITLE
chore: add Go directive bump rule to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,13 @@
       "description": "Automerge all GitHub Actions updates including major",
       "matchManagers": ["github-actions"],
       "automerge": true
+    },
+    {
+      "description": "Allow Renovate to bump go directive in go.mod",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add rangeStrategy bump for go directive in go.mod
- Enables automatic Go version updates via Renovate