### PR TITLE
fix(cli): honor --channel filter in ci latest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # goPaperMC
 
-goPaperMC is a Go client for the [PaperMC API](https://api.papermc.io), which allows you to interact with the PaperMC API to retrieve information about projects, versions, builds, and download files.
+goPaperMC is a Go client for the [PaperMC API](https://fill.papermc.io), which allows you to interact with the PaperMC API to retrieve information about projects, versions, builds, and download files.
 
 ## Features
 

--- a/cmd/papermc/cmd/ci.go
+++ b/cmd/papermc/cmd/ci.go
@@ -199,6 +199,11 @@ This will output just the latest version string, which can be used in scripts:
 		projectID := args[0]
 		client := api.NewClient()
 
+		// Apply channel filter if set
+		if ch := GetChannel(); ch != "" {
+			client.WithChannel(api.Channel(ch))
+		}
+
 		ctx := context.Background()
 
 		// Get latest version

--- a/cmd/papermc/cmd/ci_test.go
+++ b/cmd/papermc/cmd/ci_test.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/lexfrei/goPaperMC/pkg/api"
 )
 
 func TestCIMatrixCommand(t *testing.T) {
@@ -103,5 +107,59 @@ func TestCIGitHubActionsCommand(t *testing.T) {
 	// Check if we have at least one build info
 	if len(include) == 0 {
 		t.Fatal("Expected at least one build info in include field")
+	}
+}
+
+// TestCILatestCommand_ChannelFilter verifies that "ci latest" honors the
+// --channel flag. Before the fix, ciLatestCmd never consulted GetChannel(),
+// so it always returned the newest version overall even when that version
+// had no build in the requested channel.
+func TestCILatestCommand_ChannelFilter(t *testing.T) {
+	// Skip if not in CI environment or if it would make real API calls
+	if os.Getenv("CI") == "" {
+		t.Skip("Skipping test in non-CI environment")
+	}
+
+	if err := rootCmd.PersistentFlags().Set("channel", "stable"); err != nil {
+		t.Fatalf("Failed to set channel flag: %v", err)
+	}
+	defer func() {
+		_ = rootCmd.PersistentFlags().Set("channel", "")
+	}()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Execute command
+	ciLatestCmd.Run(ciLatestCmd, []string{"paper"})
+
+	// Restore stdout
+	if err := w.Close(); err != nil {
+		t.Fatalf("Failed to close writer: %v", err)
+	}
+	os.Stdout = oldStdout
+
+	// Read captured output
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("Failed to copy output: %v", err)
+	}
+	version := strings.TrimSpace(buf.String())
+
+	if version == "" {
+		t.Fatal("Expected a version to be printed")
+	}
+
+	// The returned version must actually have a stable build. This is the
+	// behavior that was previously broken by the ignored --channel flag.
+	client := api.NewClient()
+	builds, err := client.GetBuilds(context.Background(), "paper", version, api.ChannelStable)
+	if err != nil {
+		t.Fatalf("Failed to verify builds for version %q: %v", version, err)
+	}
+	if len(builds) == 0 {
+		t.Fatalf("Expected version %q returned with --channel=stable to have a stable build", version)
 	}
 }

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -388,3 +388,106 @@ func TestGetBuildDownloadURL(t *testing.T) {
 		t.Errorf("Expected direct download URL, got '%s'", url)
 	}
 }
+
+func TestGetLatestVersion_NoChannelFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := ProjectV3Response{
+			Project: ProjectMeta{ID: "paper", Name: "Paper"},
+			Versions: map[string][]string{
+				"26.1": {"26.1.2", "26.1.1"},
+				"26.2": {"26.2"},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient().WithBaseURL(server.URL)
+	version, err := client.GetLatestVersion(context.Background(), "paper")
+	if err != nil {
+		t.Fatalf("GetLatestVersion failed: %v", err)
+	}
+
+	if version != "26.2" {
+		t.Errorf("Expected latest version '26.2', got '%s'", version)
+	}
+}
+
+// TestGetLatestVersion_WithChannelFilter reproduces a real-world case: the
+// newest version overall (26.2) only ever received ALPHA/BETA builds, while
+// the previous version (26.1.2) has a STABLE build. With a stable channel
+// filter, GetLatestVersion must skip 26.2 and return 26.1.2.
+func TestGetLatestVersion_WithChannelFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v3/projects/paper":
+			resp := ProjectV3Response{
+				Project: ProjectMeta{ID: "paper", Name: "Paper"},
+				Versions: map[string][]string{
+					"26.1": {"26.1.2", "26.1.1"},
+					"26.2": {"26.2"},
+				},
+			}
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Fatalf("Failed to encode response: %v", err)
+			}
+		case "/v3/projects/paper/versions/26.2/builds":
+			// 26.2 only ever had ALPHA/BETA builds, no STABLE build exists.
+			if err := json.NewEncoder(w).Encode([]BuildV3Response{}); err != nil {
+				t.Fatalf("Failed to encode response: %v", err)
+			}
+		case "/v3/projects/paper/versions/26.1.2/builds":
+			if got := r.URL.Query().Get("channel"); got != "STABLE" {
+				t.Errorf("Expected channel=STABLE query param, got %q (raw query %q)", got, r.URL.RawQuery)
+			}
+			resp := []BuildV3Response{{ID: 10, Channel: "STABLE"}}
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Fatalf("Failed to encode response: %v", err)
+			}
+		case "/v3/projects/paper/versions/26.1.1/builds":
+			t.Error("Should not need to check 26.1.1: 26.1.2 already has a matching stable build")
+		default:
+			t.Errorf("Unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient().WithBaseURL(server.URL).WithChannel(ChannelStable)
+	version, err := client.GetLatestVersion(context.Background(), "paper")
+	if err != nil {
+		t.Fatalf("GetLatestVersion with channel filter failed: %v", err)
+	}
+
+	if version != "26.1.2" {
+		t.Errorf("Expected latest stable version '26.1.2' (26.2 has no stable build), got '%s'", version)
+	}
+}
+
+func TestGetLatestVersion_ChannelFilter_NoMatchingVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v3/projects/paper" {
+			resp := ProjectV3Response{
+				Project:  ProjectMeta{ID: "paper", Name: "Paper"},
+				Versions: map[string][]string{"26.2": {"26.2"}},
+			}
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Fatalf("Failed to encode response: %v", err)
+			}
+			return
+		}
+
+		// No version has a build in the requested channel.
+		if err := json.NewEncoder(w).Encode([]BuildV3Response{}); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient().WithBaseURL(server.URL).WithChannel(ChannelStable)
+	if _, err := client.GetLatestVersion(context.Background(), "paper"); err == nil {
+		t.Fatal("Expected error when no version has a build in the requested channel")
+	}
+}

--- a/pkg/api/download.go
+++ b/pkg/api/download.go
@@ -91,6 +91,8 @@ func (c *Client) GetLatestBuild(ctx context.Context, projectID, version string) 
 }
 
 // GetLatestVersion returns the latest available version for a project.
+// If a channel filter is set on the client (see WithChannel), only versions
+// that have at least one build in that channel are considered.
 func (c *Client) GetLatestVersion(ctx context.Context, projectID string) (string, error) {
 	projectInfo, err := c.GetProject(ctx, projectID)
 	if err != nil {
@@ -102,8 +104,27 @@ func (c *Client) GetLatestVersion(ctx context.Context, projectID string) (string
 		return "", errors.New("no versions found for this project")
 	}
 
-	// The latest version is the last one in the flattened list
-	return versions[len(versions)-1], nil
+	if c.Channel == "" {
+		// The latest version is the last one in the flattened list
+		return versions[len(versions)-1], nil
+	}
+
+	// Walk from newest to oldest and return the first version that has at
+	// least one build in the requested channel.
+	for i := len(versions) - 1; i >= 0; i-- {
+		version := versions[i]
+
+		builds, err := c.GetBuilds(ctx, projectID, version, c.Channel)
+		if err != nil {
+			continue
+		}
+
+		if len(builds) > 0 {
+			return version, nil
+		}
+	}
+
+	return "", errors.Newf("no version found with a build in channel %s", c.Channel)
 }
 
 // GetDefaultDownloadName returns the name of the main downloadable file for a build.


### PR DESCRIPTION
## Summary

- `ci latest` ignored the `--channel` flag entirely and always returned the newest version overall, even when that version has no build in the requested channel, while `matrix` and `github-actions` already applied the filter correctly.
- `GetLatestVersion` in `pkg/api` now walks versions from newest to oldest and returns the first one with a matching build when a channel filter is set on the client, leaving the no-filter behavior unchanged.
- Updated the README link that pointed at the legacy `api.papermc.io` v2 endpoint (now sunset, returns HTTP 410) to point at `fill.papermc.io`, the v3 API this client actually talks to; a repo-wide search confirmed no other v2 endpoint references remain in code, tests, or examples.

## Testing

- Added unit tests in `pkg/api` covering the channel-aware latest-version lookup, including the case where the newest version has no matching build in the requested channel.
- Added a network-backed regression test in `cmd/papermc/cmd`, gated the same way as the existing CI-only tests in that file; verified it fails against the pre-fix code (returns a version with no stable build) and passes with the fix.
- `go test ./...`, `go vet ./...`, and `golangci-lint run ./...` all pass.
